### PR TITLE
[MODI-60] 모집할 파티원 수 카운터 컴포넌트 구현

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -36,7 +36,6 @@
     "lines-between-class-members": ["error", "always"],
     "no-new-func": "error",
     "prefer-arrow-callback": "error",
-    "arrow-parens": ["error", "as-needed"],
     "implicit-arrow-linebreak": ["error", "beside"],
     "prefer-destructuring": ["error", { "object": true, "array": false }],
     "prefer-template": "error",

--- a/src/components/MemberCounter.js
+++ b/src/components/MemberCounter.js
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import { Add, Remove } from '@mui/icons-material';
+import { Button, Grid, Typography } from '@mui/material';
+import { useState } from 'react';
+
+const MemberCounter = ({ member }) => {
+  const [count, setCount] = useState(member);
+
+  const onDecrease = () => {
+    if (count > 1) {
+      setCount((prevCount) => prevCount - 1);
+    }
+  };
+
+  const onIncrease = () => {
+    if (count < 3) {
+      setCount((prevCount) => prevCount + 1);
+    }
+  };
+
+  return (
+    <Grid
+      container
+      sx={{
+        color: 'black',
+        boxShadow: 1,
+        borderRadius: 1,
+        alignItems: 'center',
+        textAlign: 'center',
+        p: 2,
+        width: 300,
+        height: 100,
+      }}
+    >
+      <Grid item xs={4}>
+        <Button onClick={onDecrease}>
+          <Remove />
+        </Button>
+      </Grid>
+      <Grid item xs={4}>
+        <Typography variant="h5" align="center">
+          {count}명
+        </Typography>
+      </Grid>
+      <Grid item xs={4}>
+        <Button onClick={onIncrease}>
+          <Add />
+        </Button>
+      </Grid>
+    </Grid>
+  );
+};
+
+MemberCounter.propTypes = {
+  member: PropTypes.number.isRequired,
+};
+
+export default MemberCounter;

--- a/src/components/MemberCounter.js
+++ b/src/components/MemberCounter.js
@@ -7,15 +7,11 @@ const MemberCounter = ({ member }) => {
   const [count, setCount] = useState(member);
 
   const onDecrease = () => {
-    if (count > 1) {
-      setCount((prevCount) => prevCount - 1);
-    }
+    count > 1 && setCount((prevCount) => prevCount - 1);
   };
 
   const onIncrease = () => {
-    if (count < 3) {
-      setCount((prevCount) => prevCount + 1);
-    }
+    count < 3 && setCount((prevCount) => prevCount + 1);
   };
 
   return (

--- a/src/components/MemberCounter.js
+++ b/src/components/MemberCounter.js
@@ -3,15 +3,17 @@ import { Add, Remove } from '@mui/icons-material';
 import { Button, Grid, Typography } from '@mui/material';
 import { useState } from 'react';
 
-const MemberCounter = ({ member }) => {
+const MemberCounter = ({ member, onClick }) => {
   const [count, setCount] = useState(member);
 
   const onDecrease = () => {
     count > 1 && setCount((prevCount) => prevCount - 1);
+    onClick(count);
   };
 
   const onIncrease = () => {
     count < 3 && setCount((prevCount) => prevCount + 1);
+    onClick(count);
   };
 
   return (
@@ -20,7 +22,7 @@ const MemberCounter = ({ member }) => {
       sx={{
         color: 'black',
         boxShadow: 1,
-        borderRadius: 1,
+        borderRadius: 20,
         alignItems: 'center',
         textAlign: 'center',
         p: 2,
@@ -49,6 +51,7 @@ const MemberCounter = ({ member }) => {
 
 MemberCounter.propTypes = {
   member: PropTypes.number.isRequired,
+  onClick: PropTypes.func,
 };
 
 export default MemberCounter;


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
<img width="307" alt="스크린샷 2021-12-06 오후 3 22 22" src="https://user-images.githubusercontent.com/39365737/144797569-bb95d9c3-f54f-4bb7-a6a4-946f6a8c2c21.png">


## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- eslint `arrow-parens` 규칙 삭제 
- MemberCounter 컴포넌트 구현
   - `-` 버튼 : 모집할 파티원 수 감소 (최소 1명)
   -  `+` 버튼 : 모집할 파티원 수 증가 (최대 3명) 

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

수정사항이나 코드 개선할 부분이 있다면 리뷰 부탁드려요 👍

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->