### PR TITLE
[MODI-59] 다중 선택 가능한 규칙 태그 목록 컴포넌트 구현

### DIFF
--- a/src/components/RuleList.js
+++ b/src/components/RuleList.js
@@ -12,7 +12,6 @@ const RuleList = ({ rules }) => {
     } else {
       setSelectedRules([...selectedRules, ruleId]);
     }
-    console.log(selectedRules);
   };
 
   return (

--- a/src/components/RuleList.js
+++ b/src/components/RuleList.js
@@ -1,0 +1,44 @@
+import PropTypes from 'prop-types';
+import { Box } from '@mui/material';
+import RuleToggle from './RuleToggle';
+import { useState } from 'react';
+
+const RuleList = ({ rules }) => {
+  const [selectedRules, setSelectedRules] = useState([]);
+
+  const handleSelectRule = ruleId => {
+    if (selectedRules.indexOf(ruleId) >= 0) {
+      const newSelectedRules = selectedRules.filter(rule => rule !== ruleId);
+      setSelectedRules(newSelectedRules);
+    } else {
+      setSelectedRules([...selectedRules, ruleId]);
+    }
+  };
+
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        p: 1,
+        m: 1,
+        maxWidth: 400,
+      }}
+    >
+      {rules.map(({ ruleId, ruleName }) => (
+        <RuleToggle
+          key={ruleId}
+          ruleId={ruleId}
+          ruleName={ruleName}
+          onSelectRule={handleSelectRule}
+        />
+      ))}
+    </Box>
+  );
+};
+
+RuleList.propTypes = {
+  rules: PropTypes.array,
+};
+
+export default RuleList;

--- a/src/components/RuleList.js
+++ b/src/components/RuleList.js
@@ -7,12 +7,12 @@ const RuleList = ({ rules }) => {
   const [selectedRules, setSelectedRules] = useState([]);
 
   const handleSelectRule = ruleId => {
-    if (selectedRules.indexOf(ruleId) >= 0) {
-      const newSelectedRules = selectedRules.filter(rule => rule !== ruleId);
-      setSelectedRules(newSelectedRules);
+    if (selectedRules.some(rule => rule === ruleId)) {
+      setSelectedRules(selectedRules.filter(rule => rule !== ruleId));
     } else {
       setSelectedRules([...selectedRules, ruleId]);
     }
+    console.log(selectedRules);
   };
 
   return (

--- a/src/components/RuleToggle.js
+++ b/src/components/RuleToggle.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import styled from '@emotion/styled';
+
+import { Chip } from '@mui/material';
+import { useState } from 'react';
+
+const Button = styled.button`
+  background-color: white;
+  border: 0px;
+`;
+
+const RuleToggle = ({ ruleId, ruleName, onSelectRule }) => {
+  const [selected, setSelected] = useState(false);
+
+  const handleClickRule = () => {
+    setSelected(!selected);
+    onSelectRule(ruleId);
+  };
+
+  return (
+    <Button>
+      <Chip
+        sx={{
+          m: 0.5,
+          cursor: 'pointer',
+          filter: 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',
+        }}
+        color={selected ? 'primary' : 'default'}
+        key={ruleId}
+        label={ruleName}
+        onClick={handleClickRule}
+      />
+    </Button>
+  );
+};
+
+RuleToggle.propTypes = {
+  ruleId: PropTypes.number,
+  ruleName: PropTypes.string,
+  onSelectRule: PropTypes.func,
+};
+
+export default RuleToggle;

--- a/src/components/RuleToggle.js
+++ b/src/components/RuleToggle.js
@@ -23,7 +23,6 @@ const RuleToggle = ({ ruleId, ruleName, onSelectRule }) => {
         sx={{
           m: 0.5,
           cursor: 'pointer',
-          filter: 'drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25))',
         }}
         color={selected ? 'primary' : 'default'}
         key={ruleId}

--- a/src/components/RuleToggle.js
+++ b/src/components/RuleToggle.js
@@ -13,7 +13,7 @@ const RuleToggle = ({ ruleId, ruleName, onSelectRule }) => {
   const [selected, setSelected] = useState(false);
 
   const handleClickRule = () => {
-    setSelected(!selected);
+    setSelected(prev => !prev);
     onSelectRule(ruleId);
   };
 


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

https://user-images.githubusercontent.com/39365737/144698200-619e8583-eec3-45b4-b5bc-4b23e477ee73.mov


## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
### RuleToggle
<img width="92" alt="스크린샷 2021-12-04 오후 2 20 00" src="https://user-images.githubusercontent.com/39365737/144698308-c6018e35-c8fd-4cf1-8490-8674022ed5f5.png">
<img width="83" alt="스크린샷 2021-12-04 오후 2 23 16" src="https://user-images.githubusercontent.com/39365737/144698403-951cb7dd-b6aa-4860-b236-0363e2e23f6d.png">

- 규칙을 클릭 시 
   - `selected` 를 `true/false`로 바꿔 style에 변경을 준다. 
   - `RuleList`로 선택된` ruleId `값을 전달한다. 


### RuleList
<img width="368" alt="스크린샷 2021-12-04 오후 2 24 47" src="https://user-images.githubusercontent.com/39365737/144698434-9dc4ab68-6602-48ab-81ec-e892bd7b0572.png">

- `ruleId`와 `ruleName` 값들이 담긴` rules`를 props를 통해 전달 받아 map을 통해 `RuleToggle`을 화면에 뿌려준다.
- `selectedRules `: 선택된 규칙들이 담긴 리스트
- `handleSelectRule `: 선택된 규칙의 ruleId를 받아온다. 
   - `ruleId`가 `selectedRules`에 있는 값이면 리스트에서 제거
   - 없는 값이면 리스트에 추가

 
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->