### PR TITLE
[MODI-106] PageHeader 컴포넌트 구현

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -13,7 +13,9 @@ const PageHeader = ({ src, alt, title, children }) => {
           sx={{ boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)' }}
         />
       )}
-      <Typography variant="large">{title}</Typography>
+      <Typography variant="large" component="h2">
+        {title}
+      </Typography>
       {children && children}
     </PageHeaderStyle>
   );

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -5,12 +5,14 @@ import { styled } from '@mui/system';
 const PageHeader = ({ src, alt, title, children }) => {
   return (
     <PageHeaderStyle>
-      <Avatar
-        src={src}
-        alt={alt}
-        size={72}
-        sx={{ boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)' }}
-      />
+      {src && (
+        <Avatar
+          src={src}
+          alt={alt}
+          size={72}
+          sx={{ boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)' }}
+        />
+      )}
       <Typography variant="large">{title}</Typography>
       {children && children}
     </PageHeaderStyle>

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -1,0 +1,34 @@
+import { Avatar, Typography, Box } from '@mui/material';
+import { PropTypes } from 'prop-types';
+import { styled } from '@mui/system';
+
+const PageHeader = ({ src, alt, title, children }) => {
+  return (
+    <PageHeaderStyle>
+      <Avatar src={src} alt={alt} size={72} />
+      <Typography variant="large">{title}</Typography>
+      {children && children}
+    </PageHeaderStyle>
+  );
+};
+
+PageHeader.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  title: PropTypes.string,
+  children: PropTypes.node,
+};
+
+const PageHeaderStyle = styled(Box)`
+  padding: 40px 30px;
+  box-sizing: border-box;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  button {
+    margin-left: auto;
+  }
+`;
+
+export default PageHeader;

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -5,7 +5,12 @@ import { styled } from '@mui/system';
 const PageHeader = ({ src, alt, title, children }) => {
   return (
     <PageHeaderStyle>
-      <Avatar src={src} alt={alt} size={72} />
+      <Avatar
+        src={src}
+        alt={alt}
+        size={72}
+        sx={{ boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)' }}
+      />
       <Typography variant="large">{title}</Typography>
       {children && children}
     </PageHeaderStyle>


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/40739041/144820003-42d56415-6ca4-4c25-822d-3492f0898015.png)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

아래 prop을 받아서 
### props
- src : avatar에서 보여줄 이미지 경로 
- alt : avatar 이미지 설명 (ex. ottName)
- title : title로 사용될 내용 text
- children: 오른쪽에 배치될 요소

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
- 타이틀에 avatar가 있는 경우 없는 경우가 있어 prop src의 유무에 따라 avatar를 조건부 렌더링 되게 구현
- 오른쪽에 버튼이 있는경우 children으로 버튼을 받는 방식으로 구현
```javascript
  <PageHeader src={modi} alt="logo" title="모두의 아이디">
    <Button type="button" size="small" variant="outlined">
      +파티
    </Button>
  </PageHeader>
```
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
- 버튼 theme 수정한게 적용되지 않아서 조금 다르게 보이네요. modi-89브랜치 merge하면 해결될겁니다.