### PR TITLE
[MODI-108] PartyInfo 컴포넌트 구현

### DIFF
--- a/src/components/PartyInfo.jsx
+++ b/src/components/PartyInfo.jsx
@@ -7,12 +7,16 @@ const PartyInfo = ({ name, info }) => {
       sx={{
         display: 'flex',
         justifyContent: 'space-between',
+        margin: 0,
       }}
+      component="dl"
     >
-      <Typography color="text.secondary" variant="small">
+      <Typography color="text.secondary" variant="small" component="dt">
         {name}
       </Typography>
-      <Typography variant="small">{info}</Typography>
+      <Typography variant="small" component="dd">
+        {info}
+      </Typography>
     </Box>
   );
 };

--- a/src/components/PartyInfo.jsx
+++ b/src/components/PartyInfo.jsx
@@ -1,0 +1,25 @@
+import { Typography, Box } from '@mui/material';
+import { PropTypes } from 'prop-types';
+
+const PartyInfo = ({ name, info }) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        justifyContent: 'space-between',
+      }}
+    >
+      <Typography color="text.secondary" variant="small">
+        {name}
+      </Typography>
+      <Typography variant="small">{info}</Typography>
+    </Box>
+  );
+};
+
+PartyInfo.propTypes = {
+  name: PropTypes.string,
+  info: PropTypes.string,
+};
+
+export default PartyInfo;


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/40739041/144864683-c10cf250-1a90-46b1-b71d-d3d614f86d7b.png)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
<PartyInfo name="서비스" info="디즈니플러스 스탠다드" />
props
name : [string] info의 타이틀
info: [string]  info 내용 

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
info 이름과 내용을 prop으로 받아보여줄 수 있게 구현해봤습니다.
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
