### PR TITLE
feat#MODI-113: 포인트 충전 alret 컴포넌트 구현

### DIFF
--- a/src/components/PointChargeAlert.jsx
+++ b/src/components/PointChargeAlert.jsx
@@ -1,0 +1,109 @@
+import { Typography, Box, Button, Divider } from '@mui/material';
+import { styled } from '@mui/system';
+import { PropTypes } from 'prop-types';
+
+const PointChargeAlert = ({ onClose, paymentPoint, myPoint }) => {
+  const priceToString = price => {
+    return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  };
+
+  return (
+    <ModalBox>
+      <Typography
+        variant="large"
+        color="error"
+        component="h3"
+        id="parent-modal-title"
+        sx={{ marginBottom: '24px' }}
+      >
+        보유 포인트가 부족합니다.
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          margin: '0 0 8px',
+        }}
+        component="dl"
+      >
+        <Typography color="text.secondary" variant="small" component="dt">
+          결제 포인트
+        </Typography>
+        <Typography variant="small" component="dd">
+          {priceToString(paymentPoint)} P
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          margin: '0 0 8px',
+        }}
+        component="dl"
+      >
+        <Typography color="text.secondary" variant="small" component="dt">
+          보유 포인트
+        </Typography>
+        <Typography variant="smallB" color="error" component="dd">
+          {priceToString(myPoint)} P
+        </Typography>
+      </Box>
+      <Divider sx={{ margin: '8px 0' }} />
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          margin: '0 0 16px',
+        }}
+        component="dl"
+      >
+        <Typography variant="baseB" color="text.primary" component="dt">
+          필요 포인트
+        </Typography>
+        <Typography variant="large" color="text.primary" component="dd">
+          {priceToString(paymentPoint - myPoint)} P
+        </Typography>
+      </Box>
+      <Button
+        variant="contained"
+        size="large"
+        sx={{
+          width: '48%',
+          marginRight: '4%',
+        }}
+      >
+        충전하기
+      </Button>
+      <Button
+        variant="outlined"
+        size="large"
+        onClick={onClose}
+        sx={{ width: '48%' }}
+      >
+        취소
+      </Button>
+    </ModalBox>
+  );
+};
+
+PointChargeAlert.propTypes = {
+  onClose: PropTypes.func,
+  paymentPoint: PropTypes.number.isRequired,
+  myPoint: PropTypes.number.isRequired,
+};
+
+const ModalBox = styled(Box)`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  padding: 24px;
+  width: 86%;
+  border-radius: 24px;
+  background-color: #fff;
+  box-shadow: 1px 2px 10px rgba(0, 0, 0, 0.25);
+  text-align: center;
+`;
+
+export default PointChargeAlert;


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/40739041/144904861-8eda0984-2381-477a-9811-e051972e9e24.png)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
### props
- onClose : 모달 닫기 함수를 받아서 취소 버튼이벤트와 연결
- paymentPoint  : [number] 결제 포인트 
- myPoint : [number] 보유 포인트

각 결제 포인트와 보유포인트를 prop으로 받아서 내부에서 필요포인트를 계산해 화면에 보여지도록 했습니다.

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
모달 test 코드
```
import { useState } from 'react';
import { CssBaseline, Modal, Button } from '@mui/material';
import PointChargeAlert from './components/PointChargeAlert';

function App() {
  const [open, setOpen] = useState(false);
  const handleOpen = () => {
    setOpen(true);
  };
  const handleClose = () => {
    setOpen(false);
  };

  return (
    <>
      <CssBaseline />

      <Button onClick={handleOpen}>Open Child Modal</Button>
      <Modal
        open={open}
        onClose={handleClose}
        aria-labelledby="parent-modal-title"
      >
        <PointChargeAlert
          onClose={handleClose}
          myPoint={12000}
          paymentPoint={20000}
        />
      </Modal>
    </>
  );
}

export default App;

```
## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
