### PR TITLE
[MODI-109] feat - PaymentInfo 컴포넌트 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+src/pages/testPages

--- a/src/components/PaymentInfo/index.jsx
+++ b/src/components/PaymentInfo/index.jsx
@@ -1,8 +1,19 @@
 import { Typography } from '@mui/material';
 import { Box, styled } from '@mui/system';
 import PropTypes from 'prop-types';
+import { useCallback, useMemo } from 'react';
+import { priceToString } from 'utils/priceToString';
 
-const PaymentInfo = ({ totalPrice }) => {
+const COMMISSION_RATE = 0.05;
+
+const PaymentInfo = ({ totalPrice, myPoint }) => {
+  const commission = useMemo(() => totalPrice * COMMISSION_RATE, [totalPrice]);
+  const extraCharge = useMemo(
+    () => totalPrice * (1 + COMMISSION_RATE),
+    [totalPrice],
+  );
+  const toNumberNotation = useCallback(price => priceToString(price), []);
+
   return (
     <>
       <Typography variant="baseB" color="text.primary">
@@ -20,7 +31,7 @@ const PaymentInfo = ({ totalPrice }) => {
           서비스 이용료
         </Typography>
         <Typography variant="small" color="text.primary">
-          8500 P
+          {toNumberNotation(totalPrice)} P
         </Typography>
       </Box>
 
@@ -37,7 +48,7 @@ const PaymentInfo = ({ totalPrice }) => {
           수수료(이용료의 5%)
         </Typography>
         <Typography variant="small" color="text.primary">
-          425 P
+          {toNumberNotation(commission)} P
         </Typography>
       </Box>
       <Box
@@ -48,7 +59,7 @@ const PaymentInfo = ({ totalPrice }) => {
           mt: 1,
         }}
       >
-        <Typography mr="auto" variant="small">
+        <Typography mr="auto" variant="small" color="text.secondary">
           보유 포인트
         </Typography>
         <ChargeButton>
@@ -57,7 +68,7 @@ const PaymentInfo = ({ totalPrice }) => {
           </Typography>
         </ChargeButton>
         <Typography variant="small" color="text.primary">
-          20000 P
+          {toNumberNotation(myPoint)} P
         </Typography>
       </Box>
       <Box
@@ -71,7 +82,7 @@ const PaymentInfo = ({ totalPrice }) => {
           결제 포인트
         </Typography>
         <Typography variant="visual" color="text.primary">
-          8925 P
+          {toNumberNotation(extraCharge)} P
         </Typography>
       </Box>
     </>
@@ -82,6 +93,7 @@ export default PaymentInfo;
 
 PaymentInfo.propTypes = {
   totalPrice: PropTypes.number.isRequired,
+  myPoint: PropTypes.number.isRequired,
 };
 
 const ChargeButton = styled('button')`
@@ -102,9 +114,3 @@ const ChargeButton = styled('button')`
     background-color: #51c4c4;
   }
 `;
-//   width: 36px;
-//   height: 24px;
-//   border-radius: 12px;
-//   border: 0px;
-//   background-color:
-// `;

--- a/src/components/PaymentInfo/index.jsx
+++ b/src/components/PaymentInfo/index.jsx
@@ -86,6 +86,17 @@ const PaymentInfo = ({ totalPrice, myPoint }) => {
           {toNumberNotation(extraCharge)} P
         </Typography>
       </Box>
+      {myPoint < totalPrice && (
+        <Typography
+          variant="microB"
+          color="error"
+          sx={{ textAlign: 'right' }}
+          component="div"
+        >
+          {' '}
+          현재 보유한 포인트가 부족합니다.
+        </Typography>
+      )}
     </>
   );
 };

--- a/src/components/PaymentInfo/index.jsx
+++ b/src/components/PaymentInfo/index.jsx
@@ -7,12 +7,21 @@ import { priceToString } from 'utils/priceToString';
 const COMMISSION_RATE = 0.05;
 
 const PaymentInfo = ({ totalPrice, myPoint }) => {
+  const toNumberNotation = useCallback(price => priceToString(price), []);
   const commission = useMemo(() => totalPrice * COMMISSION_RATE, [totalPrice]);
   const extraCharge = useMemo(
     () => totalPrice * (1 + COMMISSION_RATE),
     [totalPrice],
   );
-  const toNumberNotation = useCallback(price => priceToString(price), []);
+
+  const spaceBetweenSx = useMemo(
+    () => ({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+    }),
+    [],
+  );
 
   return (
     <>
@@ -21,9 +30,7 @@ const PaymentInfo = ({ totalPrice, myPoint }) => {
       </Typography>
       <Box
         sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
+          ...spaceBetweenSx,
           mt: 1,
         }}
       >
@@ -37,15 +44,13 @@ const PaymentInfo = ({ totalPrice, myPoint }) => {
 
       <Box
         sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
+          ...spaceBetweenSx,
           pb: 1,
           borderBottom: '2px dashed #DDDDDD',
         }}
       >
         <Typography variant="small" color="text.secondary">
-          수수료(이용료의 5%)
+          {`수수료(이용료의 ${COMMISSION_RATE * 100}%)`}
         </Typography>
         <Typography variant="small" color="text.primary">
           {toNumberNotation(commission)} P
@@ -62,22 +67,18 @@ const PaymentInfo = ({ totalPrice, myPoint }) => {
         <Typography mr="auto" variant="small" color="text.secondary">
           보유 포인트
         </Typography>
+
         <ChargeButton>
           <Typography variant="micro" color="common.white">
             충전
           </Typography>
         </ChargeButton>
+
         <Typography variant="small" color="text.primary">
           {toNumberNotation(myPoint)} P
         </Typography>
       </Box>
-      <Box
-        sx={{
-          display: 'flex',
-          justifyContent: 'space-between',
-          alignItems: 'center',
-        }}
-      >
+      <Box sx={spaceBetweenSx}>
         <Typography variant="smallB" color="text.primary">
           결제 포인트
         </Typography>
@@ -104,7 +105,7 @@ const ChargeButton = styled('button')`
   outline: 0px;
   background-color: #87cccd;
   cursor: pointer;
-  margin-right: 8px;
+  margin-right: 4px;
 
   &:hover {
     background-color: #95c4c4;

--- a/src/components/PaymentInfo/index.jsx
+++ b/src/components/PaymentInfo/index.jsx
@@ -1,0 +1,110 @@
+import { Typography } from '@mui/material';
+import { Box, styled } from '@mui/system';
+import PropTypes from 'prop-types';
+
+const PaymentInfo = ({ totalPrice }) => {
+  return (
+    <>
+      <Typography variant="baseB" color="text.primary">
+        결제정보
+      </Typography>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          mt: 1,
+        }}
+      >
+        <Typography variant="small" color="text.secondary">
+          서비스 이용료
+        </Typography>
+        <Typography variant="small" color="text.primary">
+          8500 P
+        </Typography>
+      </Box>
+
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          pb: 1,
+          borderBottom: '2px dashed #DDDDDD',
+        }}
+      >
+        <Typography variant="small" color="text.secondary">
+          수수료(이용료의 5%)
+        </Typography>
+        <Typography variant="small" color="text.primary">
+          425 P
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'flex-end',
+          alignItems: 'center',
+          mt: 1,
+        }}
+      >
+        <Typography mr="auto" variant="small">
+          보유 포인트
+        </Typography>
+        <ChargeButton>
+          <Typography variant="micro" color="common.white">
+            충전
+          </Typography>
+        </ChargeButton>
+        <Typography variant="small" color="text.primary">
+          20000 P
+        </Typography>
+      </Box>
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="smallB" color="text.primary">
+          결제 포인트
+        </Typography>
+        <Typography variant="visual" color="text.primary">
+          8925 P
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export default PaymentInfo;
+
+PaymentInfo.propTypes = {
+  totalPrice: PropTypes.number.isRequired,
+};
+
+const ChargeButton = styled('button')`
+  width: 36px;
+  height: 24px;
+  border-radius: 12px;
+  border: 0px;
+  outline: 0px;
+  background-color: #87cccd;
+  cursor: pointer;
+  margin-right: 8px;
+
+  &:hover {
+    background-color: #95c4c4;
+  }
+
+  &:active {
+    background-color: #51c4c4;
+  }
+`;
+//   width: 36px;
+//   height: 24px;
+//   border-radius: 12px;
+//   border: 0px;
+//   background-color:
+// `;

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-//import App from './App';
+import App from './App';
 import { ThemeProvider } from '@emotion/react';
 import theme from './styles/theme';
-import TestPageDorr from 'pages/testPages/TestPageDorr';
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      {/* <App /> */}
-      <TestPageDorr />
+      <App />
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import App from './App';
+//import App from './App';
 import { ThemeProvider } from '@emotion/react';
 import theme from './styles/theme';
+import TestPageDorr from 'pages/testPages/TestPageDorr';
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <App />
+      {/* <App /> */}
+      <TestPageDorr />
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/pages/testPages/TestPageDorr.jsx
+++ b/src/pages/testPages/TestPageDorr.jsx
@@ -5,7 +5,7 @@ const TestPageDorr = () => {
   return (
     <>
       <CssBaseline />
-      <PaymentInfo totalPrice={9000} myPoint={100000} />
+      <PaymentInfo totalPrice={9000} myPoint={1000} />
     </>
   );
 };

--- a/src/pages/testPages/TestPageDorr.jsx
+++ b/src/pages/testPages/TestPageDorr.jsx
@@ -1,0 +1,13 @@
+import { CssBaseline } from '@mui/material';
+import PaymentInfo from 'components/PaymentInfo/index';
+
+const TestPageDorr = () => {
+  return (
+    <>
+      <CssBaseline />
+      <PaymentInfo />
+    </>
+  );
+};
+
+export default TestPageDorr;

--- a/src/pages/testPages/TestPageDorr.jsx
+++ b/src/pages/testPages/TestPageDorr.jsx
@@ -5,7 +5,7 @@ const TestPageDorr = () => {
   return (
     <>
       <CssBaseline />
-      <PaymentInfo />
+      <PaymentInfo totalPrice={9000} myPoint={100000} />
     </>
   );
 };

--- a/src/utils/priceToString.js
+++ b/src/utils/priceToString.js
@@ -1,0 +1,3 @@
+export const priceToString = price => {
+  return price.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+};


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/80025421/144952665-8f22a4e6-7da7-431f-8c18-cdbc5092e426.png)
### 포인트 부족
![image](https://user-images.githubusercontent.com/80025421/144953665-295caf92-8606-4d47-885b-785ef9aae692.png)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] totalPrice와 myPoint을 props로 받아 결제금액을 동적으로 보여준다.
- [x] 총 결제 금액이 현재 포인트 잔액보다 작을 때 포인트 부족 알림을 보여준다.
- [ ] 충전 버튼 클릭시 충전페이지로 이동한다.    

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
