### PR TITLE
[MODI-125] CardFlip 컴포넌트 구현

### DIFF
--- a/src/components/CardFlip/index.js
+++ b/src/components/CardFlip/index.js
@@ -1,0 +1,53 @@
+import PropTypes from 'prop-types';
+import { Box } from '@mui/system';
+import { useCallback } from 'react';
+
+const CardFlip = ({ flip, onFlip, front, back }) => {
+  const handleFlipCard = useCallback(() => {
+    onFlip && onFlip();
+  }, [onFlip]);
+
+  return (
+    <Box
+      sx={{
+        position: 'relative',
+        perspective: '1000px',
+      }}
+    >
+      <Box
+        sx={{
+          position: 'absolute',
+          backfaceVisibility: 'hidden',
+          top: 0,
+          left: 0,
+          transform: `rotateY(${flip ? 180 : 0}deg)`,
+          transition: 'cubic-bezier(.85,.49,.66,1.23) 1.2s',
+        }}
+        onClick={handleFlipCard}
+      >
+        {front}
+      </Box>
+      <Box
+        sx={{
+          position: 'absolute',
+          backfaceVisibility: 'hidden',
+          top: 0,
+          left: 0,
+          transform: `rotateY(${flip ? 0 : -180}deg)`,
+          transition: 'cubic-bezier(.85,.49,.66,1.23) 1.2s',
+        }}
+        onClick={handleFlipCard}
+      >
+        {back}
+      </Box>
+    </Box>
+  );
+};
+
+CardFlip.propTypes = {
+  flip: PropTypes.bool,
+  onFlip: PropTypes.func,
+  front: PropTypes.element,
+  back: PropTypes.element,
+};
+export default CardFlip;


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

![card-flip](https://user-images.githubusercontent.com/80025421/145153060-c38aa5d8-4e3f-4ada-913d-065b92425e9c.gif)
## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] 클릭시 카드플립 애니메이션이 나타난다.

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->
- prop로 react element를 받습니다. front, back prop에 각각 카드 앞면, 뒷면에 해당하는 reactelement를 넣어주면 됩니다.

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
