### PR TITLE
[MODI-117] RuleToggle 재사용 가능한 컴포넌트로 수정

### DIFF
--- a/src/components/Common/Rule/index.js
+++ b/src/components/Common/Rule/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import { Typography } from '@mui/material';
 import { Box } from '@mui/system';
-import RuleToggle from 'components/Common/RuleToggle';
+import { RuleList } from 'components/Common';
 
 const RuleContainer = ({ rules }) => {
   return (
@@ -20,18 +20,7 @@ const RuleContainer = ({ rules }) => {
       >
         파티 규칙
       </Typography>
-      <Box
-        sx={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          mt: 1,
-          mb: 1,
-        }}
-      >
-        {rules.map(({ ruleId, ruleName }) => (
-          <RuleToggle key={ruleId} ruleName={ruleName} clickable={false} />
-        ))}
-      </Box>
+      <RuleList rules={rules} clickable={false} />
     </Box>
   );
 };

--- a/src/components/Common/Rule/index.js
+++ b/src/components/Common/Rule/index.js
@@ -1,27 +1,7 @@
 import PropTypes from 'prop-types';
 import { Typography } from '@mui/material';
 import { Box } from '@mui/system';
-
-const Rule = ({ ruleName }) => {
-  return (
-    <Box
-      sx={{
-        height: '34px',
-        lineHeight: '34px',
-        borderRadius: '17px',
-        bgcolor: '#eeeeee',
-      }}
-    >
-      <Typography variant="small" color="text.primary" ml={1} mr={1}>
-        {ruleName}
-      </Typography>
-    </Box>
-  );
-};
-
-Rule.propTypes = {
-  ruleName: PropTypes.string,
-};
+import RuleToggle from 'components/Common/RuleToggle';
 
 const RuleContainer = ({ rules }) => {
   return (
@@ -44,13 +24,12 @@ const RuleContainer = ({ rules }) => {
         sx={{
           display: 'flex',
           flexWrap: 'wrap',
-          gap: 1,
           mt: 1,
           mb: 1,
         }}
       >
         {rules.map(({ ruleId, ruleName }) => (
-          <Rule key={ruleId} ruleName={ruleName} />
+          <RuleToggle key={ruleId} ruleName={ruleName} clickable={false} />
         ))}
       </Box>
     </Box>

--- a/src/components/Common/RuleList.jsx
+++ b/src/components/Common/RuleList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Box } from '@mui/material';
 import RuleToggle from './RuleToggle';
 
-const RuleList = ({ rules, onSelectRule }) => {
+const RuleList = ({ rules, onSelectRule, clickable }) => {
   const [ruleList, setRuleList] = useState(rules);
 
   const handleSelectRule = ({ selectedId }) => {
@@ -20,7 +20,7 @@ const RuleList = ({ rules, onSelectRule }) => {
     });
 
     setRuleList(newRuleList);
-    onSelectRule(newRuleList);
+    onSelectRule && onSelectRule(newRuleList);
   };
 
   return (
@@ -37,16 +37,22 @@ const RuleList = ({ rules, onSelectRule }) => {
           ruleName={ruleName}
           isSelected={isSelected}
           onClickRule={handleSelectRule}
+          clickable={clickable}
         />
       ))}
     </Box>
   );
 };
 
+RuleList.defaultProps = {
+  clickable: true,
+};
+
 RuleList.propTypes = {
   rules: PropTypes.array,
   initialRules: PropTypes.array,
   onSelectRule: PropTypes.func,
+  clickable: PropTypes.bool,
 };
 
 export default RuleList;

--- a/src/components/Common/RuleToggle.jsx
+++ b/src/components/Common/RuleToggle.jsx
@@ -1,14 +1,14 @@
 import { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Chip } from '@mui/material';
-import styled from '@emotion/styled';
 
-const Button = styled.button`
-  background-color: white;
-  border: 0px;
-`;
-
-const RuleToggle = ({ ruleId, ruleName, isSelected, onClickRule }) => {
+const RuleToggle = ({
+  ruleId,
+  ruleName,
+  isSelected,
+  onClickRule,
+  clickable,
+}) => {
   const [selected, setSelected] = useState(isSelected);
 
   const handleClickRule = () => {
@@ -27,13 +27,22 @@ const RuleToggle = ({ ruleId, ruleName, isSelected, onClickRule }) => {
         cursor: 'pointer',
         m: 0.5,
       }}
+      style={{
+        opacity: 1,
+      }}
       color={selected ? 'primary' : 'default'}
       key={ruleId}
       label={ruleName}
+      disabled={!clickable}
       onClick={handleClickRule}
       component="button"
     />
   );
+};
+
+RuleToggle.defaultProps = {
+  isSelected: false,
+  clickable: true,
 };
 
 RuleToggle.propTypes = {
@@ -41,6 +50,7 @@ RuleToggle.propTypes = {
   ruleName: PropTypes.string,
   isSelected: PropTypes.bool,
   onClickRule: PropTypes.func,
+  clickable: PropTypes.bool,
 };
 
 export default RuleToggle;


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
<img width="480" alt="스크린샷 2021-12-10 오후 3 17 56" src="https://user-images.githubusercontent.com/39365737/145526744-11c4b3a0-ea9c-4f06-92b2-e6a6da1fba75.png">

<img width="437" alt="스크린샷 2021-12-10 오후 3 18 24" src="https://user-images.githubusercontent.com/39365737/145526790-8f594980-ba76-46ca-8f40-85d3bb01bb2c.png">

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- clickable 값을 전달 받아 스타일을 변경한다. 

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
