### PR TITLE
[MODI-151] OttItem 재사용 가능한 컴포넌트로 수정

### DIFF
--- a/src/components/Ott/OttItem.jsx
+++ b/src/components/Ott/OttItem.jsx
@@ -1,24 +1,6 @@
 import PropTypes from 'prop-types';
-import { Avatar, Button, Typography } from '@mui/material';
-import netflix from 'assets/netflix.png';
-import watcha from 'assets/watcha.png';
-import wavve from 'assets/wavve.png';
-import tving from 'assets/tving.png';
-import disney from 'assets/disney.png';
-import laftel from 'assets/laftel.png';
-import coupangPlay from 'assets/coupang-play.png';
-import primevideo from 'assets/primevideo.png';
-
-const ottImage = {
-  1: netflix,
-  2: watcha,
-  3: wavve,
-  4: tving,
-  5: disney,
-  6: laftel,
-  7: coupangPlay,
-  8: primevideo,
-};
+import { Button, Typography } from '@mui/material';
+import OttLogo from './OttLogo';
 
 const OttItem = ({
   ottId,
@@ -45,22 +27,14 @@ const OttItem = ({
       }}
       onClick={handleClickOtt}
     >
-      <Avatar
-        alt="OttName"
-        src={ottImage[ottId]}
-        sx={{
-          width: 72,
-          height: 72,
-          marginBottom: 1,
-          boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)',
-        }}
-      />
+      <OttLogo ottName={ottName} />
       <Typography
         variant="smallB"
         color="text.primary"
         align="center"
         component="p"
         sx={{
+          mt: 1,
           wordBreak: 'keep-all',
           height: '2em',
         }}

--- a/src/components/Ott/OttItem.jsx
+++ b/src/components/Ott/OttItem.jsx
@@ -1,9 +1,32 @@
 import PropTypes from 'prop-types';
-import { Button, Typography } from '@mui/material';
-import OttLogo from './OttLogo';
+import { Avatar, Button, Typography } from '@mui/material';
+import netflix from 'assets/netflix.png';
+import watcha from 'assets/watcha.png';
+import wavve from 'assets/wavve.png';
+import tving from 'assets/tving.png';
+import disney from 'assets/disney.png';
+import laftel from 'assets/laftel.png';
+import coupangPlay from 'assets/coupang-play.png';
+import primevideo from 'assets/primevideo.png';
 
-const OttItem = ({ ottId, ottName, selected, onSelectOtt }) => {
-  console.log(ottName);
+const ottImage = {
+  1: netflix,
+  2: watcha,
+  3: wavve,
+  4: tving,
+  5: disney,
+  6: laftel,
+  7: coupangPlay,
+  8: primevideo,
+};
+
+const OttItem = ({
+  ottId,
+  ottName,
+  selected = false,
+  onSelectOtt,
+  toggleable = true,
+}) => {
   const handleClickOtt = () => {
     onSelectOtt(ottId, ottName);
   };
@@ -14,21 +37,30 @@ const OttItem = ({ ottId, ottName, selected, onSelectOtt }) => {
         display: 'flex',
         alignItems: 'center',
         flexDirection: 'column',
-        filter: `grayscale(${selected ? 0 : 100}%)`,
+        opacity: toggleable ? (selected ? 1 : 0.5) : 1,
+        filter: `grayscale(${toggleable ? (selected ? 0 : 70) : 0}% )`,
         width: '25%',
         cursor: 'pointer',
         marginBottom: 4,
       }}
       onClick={handleClickOtt}
     >
-      <OttLogo ottName={ottName} />
+      <Avatar
+        alt="OttName"
+        src={ottImage[ottId]}
+        sx={{
+          width: 72,
+          height: 72,
+          marginBottom: 1,
+          boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)',
+        }}
+      />
       <Typography
         variant="smallB"
         color="text.primary"
         align="center"
         component="p"
         sx={{
-          mt: 1,
           wordBreak: 'keep-all',
           height: '2em',
         }}
@@ -39,11 +71,17 @@ const OttItem = ({ ottId, ottName, selected, onSelectOtt }) => {
   );
 };
 
+OttItem.defaultTypes = {
+  selected: false,
+  toggleable: true,
+};
+
 OttItem.propTypes = {
   ottId: PropTypes.number,
   ottName: PropTypes.string,
   selected: PropTypes.bool,
   onSelectOtt: PropTypes.func,
+  toggleable: PropTypes.bool,
 };
 
 export default OttItem;

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,28 +1,14 @@
-import { Box, Container, Typography, Avatar, Button } from '@mui/material';
+import { Box, Container, Typography } from '@mui/material';
 import { styled } from '@mui/system';
-import netflix from 'assets/netflix.png';
-import watcha from 'assets/watcha.png';
-import wavve from 'assets/wavve.png';
-import tving from 'assets/tving.png';
-import disney from 'assets/disney.png';
-import laftel from 'assets/laftel.png';
-import coupangPlay from 'assets/coupang-play.png';
-import primevideo from 'assets/primevideo.png';
-import CardSlide from 'components/Common/CardSlide';
+import { CardSlide } from 'components/Common';
+import OttItem from 'components/Ott/OttItem';
 import { ottServices } from 'constants/dummyData';
 
-const ottImage = {
-  1: netflix,
-  2: watcha,
-  3: wavve,
-  4: tving,
-  5: disney,
-  6: laftel,
-  7: coupangPlay,
-  8: primevideo,
-};
-
 const MainPage = () => {
+  const handleClickOtt = (ottId, ottName) => {
+    console.log(ottId, ottName);
+  };
+
   return (
     <Container disableGutters>
       <VisualBox>
@@ -66,38 +52,13 @@ const MainPage = () => {
           }}
         >
           {ottServices.map(({ ottId, ottName }) => (
-            <Button
+            <OttItem
               key={ottId}
-              sx={{
-                width: '25%',
-                textAlign: 'center',
-                mb: 2,
-                display: 'block',
-              }}
-            >
-              <Avatar
-                alt={`${ottName}logo`}
-                src={ottImage[ottId]}
-                sx={{
-                  width: 72,
-                  height: 72,
-                  m: 'auto',
-                  mb: 1,
-                  boxShadow: '0px 4px 4px rgba(0, 0, 0, 0.15)',
-                }}
-              />
-              <Typography
-                variant="smallB"
-                component="p"
-                color="text.primary"
-                sx={{
-                  wordBreak: 'keep-all',
-                  height: '2em',
-                }}
-              >
-                {ottName}
-              </Typography>
-            </Button>
+              ottId={ottId}
+              ottName={ottName}
+              onSelectOtt={handleClickOtt}
+              toggleable={false}
+            />
           ))}
         </Box>
       </Box>


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
<img width="487" alt="스크린샷 2021-12-10 오후 3 45 27" src="https://user-images.githubusercontent.com/39365737/145529658-0c6d44fa-9b03-4a14-95de-24a3d6b6eaae.png">
<img width="514" alt="스크린샷 2021-12-10 오후 3 45 41" src="https://user-images.githubusercontent.com/39365737/145529685-f720b3a2-42a9-4290-bea8-59ad7aee079e.png">


## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] toggleable 에 따라 토글 가능한 ott 이미지 / 페이지 이동 이벤트 로 재사용 가능 
- [x] 파티 만들기 페이지 ott 이미지 스타일 수정
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
