### PR TITLE
[MODI-182] authContext 구현 및 OauthRedirectPage 적용

### DIFF
--- a/src/contexts/authContext.jsx
+++ b/src/contexts/authContext.jsx
@@ -1,0 +1,107 @@
+import PropTypes from 'prop-types';
+import { useReducer, createContext, useContext } from 'react';
+
+const getUserId = () => JSON.stringify(sessionStorage.getItem('userId'));
+
+const getToken = () => JSON.stringify(sessionStorage.getItem('TOKEN'));
+
+const isLoggedIn = !!(getUserId() && getToken());
+
+const INITIAL_STATE = {
+  isLoggedIn,
+  userName: '',
+  points: null,
+  myparties: [],
+};
+
+const ACTION_TYPES = {
+  UPDATE: 'update',
+  LOGIN: 'login',
+  LOGOUT: 'logout',
+};
+
+const ACTIONS = {
+  [ACTION_TYPES.UPDATE]: (state, action) => {
+    const newValue = action.payload;
+
+    return {
+      ...state,
+      ...newValue,
+    };
+  },
+  [ACTION_TYPES.LOGIN]: state => {
+    return {
+      ...state,
+      isLoggedIn: true,
+    };
+  },
+  [ACTION_TYPES.LOGOUT]: () => {
+    return {
+      ...INITIAL_STATE,
+      isLoggedIn: false,
+    };
+  },
+};
+
+const AuthReducer = (state, action) => {
+  return ACTIONS[action.type](state, action) || state;
+};
+
+const AuthState = createContext(null);
+const AuthDispatch = createContext(null);
+
+export const AuthProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
+
+  const handleUpdate = newValue => {
+    dispatch({
+      type: ACTION_TYPES.UPDATE,
+      payload: newValue,
+    });
+  };
+
+  const handleLogin = () => {
+    dispatch({ type: ACTION_TYPES.LOGIN });
+  };
+
+  const handleLogout = () => {
+    sessionStorage.clear();
+    dispatch({ type: ACTION_TYPES.LOGOUT });
+  };
+
+  const actions = {
+    onUpdate: handleUpdate,
+    onLogin: handleLogin,
+    onLogout: handleLogout,
+  };
+
+  return (
+    <AuthState.Provider value={state}>
+      <AuthDispatch.Provider value={actions}>{children}</AuthDispatch.Provider>
+    </AuthState.Provider>
+  );
+};
+
+AuthProvider.propTypes = {
+  children: PropTypes.node.isRequired,
+};
+
+export const useAuthState = () => {
+  const state = useContext(AuthState);
+
+  if (!state) {
+    throw new Error(`Cannot find authState`);
+  }
+
+  return state;
+};
+
+export const useAuthDispatch = () => {
+  const dispatch = useContext(AuthDispatch);
+
+  if (!dispatch) {
+    throw new Error(`Cannot find authDispatch`);
+  }
+
+  return dispatch;
+};

--- a/src/contexts/authContext.jsx
+++ b/src/contexts/authContext.jsx
@@ -1,9 +1,9 @@
 import PropTypes from 'prop-types';
-import { useReducer, createContext, useContext } from 'react';
+import { useCallback, useReducer, createContext, useContext } from 'react';
 
-const getUserId = () => JSON.stringify(sessionStorage.getItem('userId'));
+const getUserId = () => JSON.parse(sessionStorage.getItem('userId'));
 
-const getToken = () => JSON.stringify(sessionStorage.getItem('TOKEN'));
+const getToken = () => JSON.parse(sessionStorage.getItem('TOKEN'));
 
 const isLoggedIn = !!(getUserId() && getToken());
 
@@ -53,16 +53,16 @@ const AuthDispatch = createContext(null);
 export const AuthProvider = ({ children }) => {
   const [state, dispatch] = useReducer(AuthReducer, INITIAL_STATE);
 
-  const handleUpdate = newValue => {
+  const handleUpdate = useCallback(newValue => {
     dispatch({
       type: ACTION_TYPES.UPDATE,
       payload: newValue,
     });
-  };
+  }, []);
 
-  const handleLogin = () => {
+  const handleLogin = useCallback(() => {
     dispatch({ type: ACTION_TYPES.LOGIN });
-  };
+  }, []);
 
   const handleLogout = () => {
     sessionStorage.clear();

--- a/src/index.js
+++ b/src/index.js
@@ -6,12 +6,15 @@ import theme from './styles/theme';
 import { CssBaseline } from '@mui/material';
 
 import Router from './Router';
+import { AuthProvider } from 'contexts/authContext';
 
 ReactDOM.render(
   <React.StrictMode>
     <ThemeProvider theme={theme}>
-      <CssBaseline />
-      <Router />
+      <AuthProvider>
+        <CssBaseline />
+        <Router />
+      </AuthProvider>
     </ThemeProvider>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/pages/OauthRedirectPage.jsx
+++ b/src/pages/OauthRedirectPage.jsx
@@ -1,23 +1,48 @@
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import useStorage from 'hooks/useStorage';
 import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useAuthDispatch } from 'contexts/authContext';
+import { getMyInfo } from 'utils/api';
+import useAsync from 'hooks/useAsync';
 
 const OauthRedirectPage = () => {
+  const { onUpdate, onLogin } = useAuthDispatch();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
-
   const jwtToken = searchParams.get('token');
 
-  const [storedValue, setValue] = useStorage('TOKEN', '', 'session');
+  const [, setValue] = useStorage('TOKEN', jwtToken, 'session');
+
+  const [getMyInfoAPIState, fetchGetMyInfoAPIState] = useAsync(
+    getMyInfo(),
+    [],
+    true,
+  );
+
+  const { isLoading, value, error } = getMyInfoAPIState;
+  useEffect(() => {
+    setValue(jwtToken);
+  }, [setValue, jwtToken]);
 
   useEffect(() => {
-    setValue(() => {
-      sessionStorage.removeItem('TOKEN');
+    fetchGetMyInfoAPIState();
+  }, [fetchGetMyInfoAPIState]);
 
-      return jwtToken;
-    });
-    navigate('/');
-  }, [storedValue, setValue, navigate, jwtToken]);
+  useEffect(() => {
+    if (value) {
+      onUpdate(value);
+      onLogin();
+      navigate('/');
+    }
+  }, [onLogin, onUpdate, value, navigate]);
+
+  if (isLoading) {
+    <h1>로그인중...</h1>;
+  }
+
+  if (error) {
+    <h1>에러</h1>;
+  }
 
   return (
     <>

--- a/src/utils/api/index.js
+++ b/src/utils/api/index.js
@@ -3,8 +3,6 @@ import { API_END_POINT } from 'constants/environment';
 
 import * as httpMethods from 'constants/httpMethods';
 
-const TOKEN = JSON.parse(sessionStorage.getItem('TOKEN'));
-
 const instance = axios.create({
   baseURL: API_END_POINT,
 });
@@ -13,7 +11,11 @@ const axiosRequest = (uri, requireToken, method = httpMethods.GET, data) => {
   const args = [uri];
 
   data && args.push(data);
-  requireToken && args.push({ headers: { Authorization: `Bearer ${TOKEN}` } });
+
+  if (requireToken) {
+    const TOKEN = JSON.parse(sessionStorage.getItem('TOKEN'));
+    args.push({ headers: { Authorization: `Bearer ${TOKEN}` } });
+  }
 
   return instance[method](...args).then(response => response.data);
 };


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] 로그인 상태, userName, points, myParties 등을 관리하는 authContext를 구현
- [x] AuthState, AuthDispatch 두가지 Context를 엮어 AuthProvider 컴포넌트 구현
- [x] onUpdate 함수를 통해 전역 state값 최신화 가능
- [x] onLogin, onLogout 함수를 통해 로그인 상태 관리 가능
- [x] OauthRedirectPage의 URL에서 token 파싱후 sessionStorage에 저장
- [x] OauthRedirectPage에서 getMyInfo API호출후 결과를 AuthState context에 저장

 
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
