### PR TITLE
[hotfix] useAsync의 return 값인 callback 함수에 인수를 받지 못하는 오류 수정

### DIFF
--- a/src/hooks/useAsync.js
+++ b/src/hooks/useAsync.js
@@ -39,15 +39,15 @@ const asyncReducer = (_state, action) => {
   }
 };
 
-const useAsync = (fn, deps = [], skip = false) => {
+const useAsync = (fn, initialArgs = [], deps = [], skip = false) => {
   const lastCallId = useRef(0);
   const [state, dispatch] = useReducer(asyncReducer, initialAsyncState);
 
   const callback = useCallback(
-    async (...args) => {
+    async (...newArgs) => {
       const callId = ++lastCallId.current;
       dispatch({ type: 'loading' });
-
+      const args = newArgs.length ? newArgs : initialArgs;
       try {
         const value = await fn(...args);
 
@@ -70,8 +70,9 @@ const useAsync = (fn, deps = [], skip = false) => {
   );
 
   useEffect(() => {
-    !skip && callback();
-  }, [skip, callback]);
+    !skip && callback(...initialArgs);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [...initialArgs, skip, callback]);
 
   return [state, callback];
 };

--- a/src/pages/testPages/TestPageDorr.jsx
+++ b/src/pages/testPages/TestPageDorr.jsx
@@ -1,9 +1,9 @@
 import { CssBaseline } from '@mui/material';
 import useAsync from 'hooks/useAsync';
-import { getMyInfo } from 'utils/api';
+import { getOtt } from 'utils/api';
 
 const TestPageDorr = () => {
-  const [state, callback] = useAsync(getMyInfo());
+  const [state, callback] = useAsync(getOtt, [1]);
   const { isLoading, value, error } = state;
 
   console.log(isLoading, value, error);
@@ -23,6 +23,8 @@ const TestPageDorr = () => {
     <>
       <CssBaseline />
       <button onClick={() => callback()}>불러오기</button>
+      <button onClick={() => callback(5)}>불러오기</button>
+      <button onClick={() => callback(4)}>불러오기</button>
     </>
   );
 };

--- a/src/utils/api/index.js
+++ b/src/utils/api/index.js
@@ -32,9 +32,9 @@ const post = (uri, requireToken = false, data = {}) => {
 
 // const _delete = (uri, requireToken) => axiosRequest(uri, requireToken);
 
-export const getOttList = () => () => get('/otts');
-export const getOtt = ottId => () => get(`/otts/${ottId}`);
-export const getOttWaitings = () => () => get('/otts/waitings');
+export const getOttList = () => get('/otts');
+export const getOtt = ottId => get(`/otts/${ottId}`);
+export const getOttWaitings = () => get('/otts/waitings');
 export const getRecruitingParties = (ottId, size = 5, lastPartyId) => {
   let searchParamObj = { size };
 
@@ -48,29 +48,27 @@ export const getRecruitingParties = (ottId, size = 5, lastPartyId) => {
   const searchParams = new URLSearchParams(searchParamObj);
   const stringifyParams = searchParams.toString();
 
-  return () => {
-    return get(`/otts/${ottId}/parties?${stringifyParams}`);
-  };
+  return get(`/otts/${ottId}/parties?${stringifyParams}`);
 };
-export const getPartyDetail = partyId => () => get(`/parties/${partyId}`);
-export const getRules = () => () => get(`/rules`);
+export const getPartyDetail = partyId => get(`/parties/${partyId}`);
+export const getRules = () => get(`/rules`);
 
 export const createNewParty = newPartyData => {
-  return () => post(`/parties`, true, newPartyData);
+  return post(`/parties`, true, newPartyData);
 };
 
-export const requestPartyJoin = partyId => () => {
+export const requestPartyJoin = partyId => {
   return post(`/parties/${partyId}/join`, true);
 };
 
 export const getSharedAccountInfo = partyId => {
-  return () => get(`/parties/${partyId}/sharedAccount`, true);
+  return get(`/parties/${partyId}/sharedAccount`, true);
 };
 
-export const chargePoint = point => () => post(`/points/add`, true, point);
-export const getMyPoint = () => () => get(`/users/me/points`, true);
+export const chargePoint = point => post(`/points/add`, true, point);
+export const getMyPoint = () => get(`/users/me/points`, true);
 
-export const getMyInfo = () => () => get(`/users/me`, true);
+export const getMyInfo = () => get(`/users/me`, true);
 export const getAllMyParty = (status = 'RECEUITING', size = 5, lastPartyId) => {
   let searchParamObj = {
     status,
@@ -87,8 +85,8 @@ export const getAllMyParty = (status = 'RECEUITING', size = 5, lastPartyId) => {
   const searchParams = new URLSearchParams(searchParamObj);
   const stringifyParams = searchParams.toString();
 
-  return () => get(`/users/me/parties?${stringifyParams}`, true);
+  return get(`/users/me/parties?${stringifyParams}`, true);
 };
-export const getMyPartyById = partyId => () => {
+export const getMyPartyById = partyId => {
   return get(`/users/me/parties/${partyId}`, true);
 };


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- 기본 useAsync 함수의 반환함수가 변경된 인수를 받지 못하는 현상을 수정하였습니다.
- 기존 useAsync함수는 인수로 함수의 반환값을 받는 방식에서 함수와, 최초 인수값 배열을 받는 방식으로 로직을 변경하였습니다.
ex)` useAsync(getPartyDetail(1, 5, 2)) -> useAsync(getPartyDetail, [1, 5, 2])`


## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
