### PR TITLE
[MODI-209] 파티 멤버 아이콘 개수 수정

### DIFF
--- a/src/components/Common/PartyMemberList.jsx
+++ b/src/components/Common/PartyMemberList.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import { Box, Typography } from '@mui/material';
 import PartyMember from './PartyMember';
 
-const PartyMemberList = ({ members }) => {
+const PartyMemberList = ({ members, partyMemberCapacity }) => {
   const waitingMemeber = () => {
     const waitingMemberList = [];
-    for (let i = members.length + 1; i <= 4; i++) {
+    for (let i = members.length + 1; i <= partyMemberCapacity; i++) {
       waitingMemberList.push(<PartyMember key={i} isWaiting={true} />);
     }
 
@@ -48,6 +48,7 @@ const PartyMemberList = ({ members }) => {
 
 PartyMemberList.propTypes = {
   members: PropTypes.array,
+  partyMemberCapacity: PropTypes.number,
 };
 
 export default PartyMemberList;

--- a/src/components/PartyJoin/PartyDetail.jsx
+++ b/src/components/PartyJoin/PartyDetail.jsx
@@ -19,6 +19,7 @@ const PartyDetail = ({ partyDetail }) => {
     startDate,
     endDate,
     members,
+    partyMemberCapacity,
   } = partyDetail;
 
   const navigate = useNavigate();
@@ -40,7 +41,10 @@ const PartyDetail = ({ partyDetail }) => {
         monthlyFee={monthlyPrice}
       />
       <RuleContainer rules={rules} />
-      <PartyMemberList members={members} />
+      <PartyMemberList
+        members={members}
+        partyMemberCapacity={partyMemberCapacity}
+      />
       <Button
         variant="contained"
         sx={{

--- a/src/components/PartyJoin/PartyList.jsx
+++ b/src/components/PartyJoin/PartyList.jsx
@@ -6,7 +6,6 @@ const PartyList = ({ parties, onClickParty }) => {
   const handleClickParty = partyId => {
     onClickParty && onClickParty(partyId);
   };
-  console.log(parties);
 
   return (
     <List sx={{ width: '100%' }}>

--- a/src/pages/MyPartyDetailPage.jsx
+++ b/src/pages/MyPartyDetailPage.jsx
@@ -39,6 +39,7 @@ const MyPartyDetailPage = () => {
     endDate = '',
     totalPrice = 0,
     monthlyReimbursement = 0,
+    partyMemberCapacity = 0,
     status = '',
   } = PartyDetail || {};
 
@@ -149,7 +150,10 @@ const MyPartyDetailPage = () => {
             )}
           </Box>
           <Divider />
-          <PartyMemberList members={members} />
+          <PartyMemberList
+            members={members}
+            partyMemberCapacity={partyMemberCapacity}
+          />
           <Divider
             sx={{
               mt: 2,


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
<img width="686" alt="스크린샷 2021-12-16 오후 6 29 36" src="https://user-images.githubusercontent.com/39365737/146345075-d5ff693d-0d1c-487e-b360-8a025b0d5237.png">
<img width="648" alt="스크린샷 2021-12-16 오후 6 29 58" src="https://user-images.githubusercontent.com/39365737/146345134-b582a48f-3670-4bd0-9a14-c8c08c757140.png">


## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

무조건 4인 아이콘 기준으로 출력에서 
모집인원 개수만큼만 출력되도록 수정
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
