### PR TITLE
fix: RecruitingPartyPage 로딩중 문구와 모집중인 파티가 없습니다 문구 동시출력 문제 해결

### DIFF
--- a/src/components/MyParty/UserNameEdit.jsx
+++ b/src/components/MyParty/UserNameEdit.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import { Box } from '@mui/system';
 import { Button, Typography } from '@mui/material';
 import CachedIcon from '@mui/icons-material/Cached';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ChipList from 'components/Common/ChipList';
 
 const UserNameEdit = ({

--- a/src/pages/CreatePartyPage.jsx
+++ b/src/pages/CreatePartyPage.jsx
@@ -36,6 +36,7 @@ const CreatePartyPage = () => {
     sharedPassword: '',
     sharedPasswordCheck: '',
   });
+
   const location = useLocation();
   const navigate = useNavigate();
   const [currentOtt, loadOttInfo] = useAsync(

--- a/src/pages/RecrutingPartyPage.jsx
+++ b/src/pages/RecrutingPartyPage.jsx
@@ -1,4 +1,10 @@
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import {
+  useState,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+} from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { Button, IconButton, Modal } from '@mui/material';
 import AddCircleIcon from '@mui/icons-material/AddCircle';
@@ -61,7 +67,7 @@ const RecrutingPartyPage = () => {
     error: partyDetailError,
   } = partyDetailApiState;
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (partyListValue) {
       const { partyList, totalSize } = partyListValue;
 
@@ -135,15 +141,17 @@ const RecrutingPartyPage = () => {
             alignItems: 'center',
           }}
         >
-          {currPartyList.length !== 0 ? (
-            <PartyList
-              parties={currPartyList}
-              onClickParty={handleFetchPartyDetail}
-            />
-          ) : (
-            <PartyNoneItem />
-          )}
           {partyListLoading && <h1>로딩중</h1>}
+          {!partyListLoading &&
+            (currPartyList.length !== 0 ? (
+              <PartyList
+                parties={currPartyList}
+                onClickParty={handleFetchPartyDetail}
+              />
+            ) : (
+              <PartyNoneItem />
+            ))}
+
           {partyListError && <div>에러</div>}
           {totalPartySize !== currPartyList.length && (
             <Button


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![fix-recruiting-page](https://user-images.githubusercontent.com/80025421/146680458-5735c676-2516-4fd1-9ac7-b079313ccd92.gif)


## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->

## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
