### PR TITLE
[MODI-294] feat- 채팅리스트 페이지의 레이아웃 구현

### DIFF
--- a/src/Router.jsx
+++ b/src/Router.jsx
@@ -13,6 +13,7 @@ import PointChargePage from 'pages/PointChargePage';
 import NotFoundPage from './pages/NotFoundPage';
 import PrivateRoute from 'utils/PrivateRoute';
 import LoginAlertPage from 'pages/LoginAlertPage';
+import ChatPage from 'pages/ChatPage';
 
 const Router = () => {
   return (
@@ -68,6 +69,7 @@ const Router = () => {
           />
           <Route path="/needlogin" element={<LoginAlertPage />} />
           <Route path="*" element={<NotFoundPage />} />
+          <Route path="chat" element={<ChatPage />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/Chat/ChatRoomList.jsx
+++ b/src/components/Chat/ChatRoomList.jsx
@@ -1,34 +1,69 @@
 import { List } from '@mui/material';
 
 import ChatRoomListItem from './ChatRoomListItem';
+const CHAT_ROOM_LIST_DUMMY = {
+  chatListItemArray: [
+    {
+      partyId: 1,
+      ottName: '넷플릭스',
+      partyLeaderName: '조용한 사슴',
+      latestMessageText:
+        '오늘부터 공유계정의 비밀번호를 변경하였습니다. 확인부탁드립니다.',
+      countNotReadMessage: 100,
+    },
+    {
+      partyId: 2,
+      ottName: '쿠팡 플레이',
+      partyLeaderName: '살찐 고양이',
+      latestMessageText:
+        '비매너 행동을 하는 멤버가 있는 것 같은데 주의부탁드립니다. ',
+      countNotReadMessage: 3,
+    },
+    {
+      partyId: 3,
+      ottName: '라프텔',
+      partyLeaderName: '언짢은 강아지',
+      latestMessageText:
+        '오늘부터 같이 파티를 하게 되었네요! 잘 부탁드려요 ㅋㅋㅋ ',
+      countNotReadMessage: 0,
+    },
+    {
+      partyId: 4,
+      ottName: '아마존 프라임',
+      partyLeaderName: '조용한 사슴',
+      latestMessageText: '아 자꾸 비매너 행동하시는데 계속 이러시면 신고합니다',
+      countNotReadMessage: 122,
+    },
+    {
+      partyId: 1,
+      ottName: '웨이브',
+      partyLeaderName: '좋은 카멜레온',
+      latestMessageText: '혹시 지금 저만 계정 접속이 안되나요??',
+      countNotReadMessage: 83,
+    },
+  ],
+};
 
 const ChatRoomList = () => {
   return (
     <List>
-      <ChatRoomListItem
-        ottName="넷플릭스"
-        partyLeaderName="조용한 사슴"
-        latestMessageText="비밀번호 바꿈 ㅅㄱ 님들 이제 이용불가임 zzzzzzzzzzz"
-        countNotReadMessage={100}
-      />
-      <ChatRoomListItem
-        ottName="쿠팡 플레이"
-        partyLeaderName="살찐 고양이"
-        latestMessageText="님들이랑 같이 못하겠음 탈주함 ㅂㅂ"
-        countNotReadMessage={10}
-      />
-      <ChatRoomListItem
-        ottName="라프텔"
-        partyLeaderName="언짢은 강아지"
-        latestMessageText="오늘부터 시작 맞나요??"
-        countNotReadMessage={1}
-      />
-      <ChatRoomListItem
-        ottName="아마존 프라임"
-        partyLeaderName="좋은 호랑이"
-        latestMessageText="내일까지 파티원 못 구하면 파티 폭파합니다."
-        countNotReadMessage={56}
-      />
+      {CHAT_ROOM_LIST_DUMMY.chatListItemArray.map(
+        ({
+          partyId,
+          ottName,
+          partyLeaderName,
+          latestMessageText,
+          countNotReadMessage,
+        }) => (
+          <ChatRoomListItem
+            key={partyId}
+            ottName={ottName}
+            partyLeaderName={partyLeaderName}
+            latestMessageText={latestMessageText}
+            countNotReadMessage={countNotReadMessage}
+          />
+        ),
+      )}
     </List>
   );
 };

--- a/src/components/Chat/ChatRoomList.jsx
+++ b/src/components/Chat/ChatRoomList.jsx
@@ -1,0 +1,36 @@
+import { List } from '@mui/material';
+
+import ChatRoomListItem from './ChatRoomListItem';
+
+const ChatRoomList = () => {
+  return (
+    <List>
+      <ChatRoomListItem
+        ottName="넷플릭스"
+        partyLeaderName="조용한 사슴"
+        latestMessageText="비밀번호 바꿈 ㅅㄱ 님들 이제 이용불가임 zzzzzzzzzzz"
+        countNotReadMessage={100}
+      />
+      <ChatRoomListItem
+        ottName="쿠팡 플레이"
+        partyLeaderName="살찐 고양이"
+        latestMessageText="님들이랑 같이 못하겠음 탈주함 ㅂㅂ"
+        countNotReadMessage={10}
+      />
+      <ChatRoomListItem
+        ottName="라프텔"
+        partyLeaderName="언짢은 강아지"
+        latestMessageText="오늘부터 시작 맞나요??"
+        countNotReadMessage={1}
+      />
+      <ChatRoomListItem
+        ottName="아마존 프라임"
+        partyLeaderName="좋은 호랑이"
+        latestMessageText="내일까지 파티원 못 구하면 파티 폭파합니다."
+        countNotReadMessage={56}
+      />
+    </List>
+  );
+};
+
+export default ChatRoomList;

--- a/src/components/Chat/ChatRoomListItem.jsx
+++ b/src/components/Chat/ChatRoomListItem.jsx
@@ -5,6 +5,7 @@ import {
   ListItem,
   ListItemAvatar,
   ListItemText,
+  ListItemButton,
   Typography,
 } from '@mui/material';
 import OttLogo from 'components/Ott/OttLogo';
@@ -19,47 +20,76 @@ const ChatRoomListItem = ({
   return (
     <>
       <ListItem
+        disableGutters
+        disablePadding
+        divider
         sx={{
           mt: 1.5,
           mb: 1.5,
+          cursor: 'pointer',
         }}
       >
-        <ListItemAvatar>
-          <OttLogo ottName={ottName} size={45} />
-        </ListItemAvatar>
-        <ListItemText disableTypography>
-          <Box
+        <ListItemButton
+          sx={{
+            width: '100%',
+          }}
+        >
+          <ListItemAvatar>
+            <OttLogo ottName={ottName} size={45} />
+          </ListItemAvatar>
+          <ListItemText
+            disableTypography
             sx={{
-              display: 'flex',
-              alignItems: 'center',
+              width: '100%',
             }}
           >
             <Box
               sx={{
-                width: '100%',
-                pr: 4,
+                display: 'flex',
+                justifyContent: 'space-between',
+                alignItems: 'center',
               }}
             >
-              <Typography variant="smallB" component="div" mb={0.5}>
-                {`${partyLeaderName}의 ${ottName}`}
-              </Typography>
-              <Typography
-                variant="micro"
-                component="div"
+              <Box
                 sx={{
-                  overflow: 'hidden',
-                  whiteSpace: 'nowrap',
-                  textOverflow: 'ellipsis',
+                  width: '80%',
                 }}
               >
-                {latestMessageText}
-              </Typography>
+                <Typography
+                  variant="smallB"
+                  component="div"
+                  mb={0.5}
+                  sx={{
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {`${partyLeaderName}의 ${ottName}`}
+                </Typography>
+                <Typography
+                  variant="micro"
+                  component="div"
+                  sx={{
+                    overflow: 'hidden',
+                    whiteSpace: 'nowrap',
+                    textOverflow: 'ellipsis',
+                  }}
+                >
+                  {latestMessageText}
+                </Typography>
+              </Box>
+              <Badge
+                badgeContent={countNotReadMessage}
+                color="primary"
+                sx={{
+                  mr: 2,
+                }}
+              />
             </Box>
-            <Badge badgeContent={countNotReadMessage} color="primary" />
-          </Box>
-        </ListItemText>
+          </ListItemText>
+        </ListItemButton>
       </ListItem>
-      <Divider />
     </>
   );
 };

--- a/src/components/Chat/ChatRoomListItem.jsx
+++ b/src/components/Chat/ChatRoomListItem.jsx
@@ -1,7 +1,6 @@
 import {
   Badge,
   Box,
-  Divider,
   ListItem,
   ListItemAvatar,
   ListItemText,
@@ -19,19 +18,13 @@ const ChatRoomListItem = ({
 }) => {
   return (
     <>
-      <ListItem
-        disableGutters
-        disablePadding
-        divider
-        sx={{
-          mt: 1.5,
-          mb: 1.5,
-          cursor: 'pointer',
-        }}
-      >
+      <ListItem disableGutters disablePadding divider>
         <ListItemButton
           sx={{
             width: '100%',
+            background: 'transparent',
+            pt: 2,
+            pb: 2,
           }}
         >
           <ListItemAvatar>

--- a/src/components/Chat/ChatRoomListItem.jsx
+++ b/src/components/Chat/ChatRoomListItem.jsx
@@ -1,0 +1,84 @@
+import {
+  Badge,
+  Box,
+  Divider,
+  ListItem,
+  ListItemAvatar,
+  ListItemText,
+  Typography,
+} from '@mui/material';
+import OttLogo from 'components/Ott/OttLogo';
+import PropTypes from 'prop-types';
+
+const ChatRoomListItem = ({
+  ottName,
+  partyLeaderName,
+  latestMessageText,
+  countNotReadMessage,
+}) => {
+  return (
+    <>
+      <ListItem
+        sx={{
+          mt: 1.5,
+          mb: 1.5,
+        }}
+      >
+        <ListItemAvatar>
+          <OttLogo ottName={ottName} size={45} />
+        </ListItemAvatar>
+        <ListItemText disableTypography>
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+            }}
+          >
+            <Box
+              sx={{
+                width: '100%',
+                pr: 4,
+              }}
+            >
+              <Typography variant="smallB" component="div" mb={0.5}>
+                {`${partyLeaderName}의 ${ottName}`}
+              </Typography>
+              <Typography
+                variant="micro"
+                component="div"
+                sx={{
+                  overflow: 'hidden',
+                  whiteSpace: 'nowrap',
+                  textOverflow: 'ellipsis',
+                }}
+              >
+                {latestMessageText}
+              </Typography>
+            </Box>
+            <Badge badgeContent={countNotReadMessage} color="primary" />
+          </Box>
+        </ListItemText>
+      </ListItem>
+      <Divider />
+    </>
+  );
+};
+
+ChatRoomListItem.propTypes = {
+  ottName: PropTypes.oneOf([
+    '넷플릭스',
+    '왓챠',
+    '웨이브',
+    '티빙',
+    '디즈니 플러스',
+    '라프텔',
+    '쿠팡 플레이',
+    '아마존 프라임',
+    '',
+  ]),
+  partyLeaderName: PropTypes.string,
+  latestMessageText: PropTypes.string,
+  countNotReadMessage: PropTypes.number,
+};
+
+export default ChatRoomListItem;

--- a/src/components/Chat/ChatRoomListItem.jsx
+++ b/src/components/Chat/ChatRoomListItem.jsx
@@ -16,6 +16,12 @@ const ChatRoomListItem = ({
   latestMessageText,
   countNotReadMessage,
 }) => {
+  const textOverflowEllipsisSx = {
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+  };
+
   return (
     <>
       <ListItem disableGutters disablePadding divider>
@@ -52,22 +58,14 @@ const ChatRoomListItem = ({
                   variant="smallB"
                   component="div"
                   mb={0.5}
-                  sx={{
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                  }}
+                  sx={textOverflowEllipsisSx}
                 >
                   {`${partyLeaderName}의 ${ottName}`}
                 </Typography>
                 <Typography
                   variant="micro"
                   component="div"
-                  sx={{
-                    overflow: 'hidden',
-                    whiteSpace: 'nowrap',
-                    textOverflow: 'ellipsis',
-                  }}
+                  sx={textOverflowEllipsisSx}
                 >
                   {latestMessageText}
                 </Typography>

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -1,0 +1,14 @@
+import PageContainer from 'components/Common/PageContainer';
+import PageContents from 'components/Common/PageContents';
+import PageHeader from 'components/Common/PageHeader';
+
+const ChatPage = () => {
+  return (
+    <PageContainer>
+      <PageHeader title="메세지" />
+      <PageContents>채팅방 리스트</PageContents>
+    </PageContainer>
+  );
+};
+
+export default ChatPage;

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -1,3 +1,4 @@
+import ChatRoomList from 'components/Chat/ChatRoomList';
 import PageContainer from 'components/Common/PageContainer';
 import PageContents from 'components/Common/PageContents';
 import PageHeader from 'components/Common/PageHeader';
@@ -6,7 +7,9 @@ const ChatPage = () => {
   return (
     <PageContainer>
       <PageHeader title="메세지" />
-      <PageContents>채팅방 리스트</PageContents>
+      <PageContents>
+        <ChatRoomList />
+      </PageContents>
     </PageContainer>
   );
 };


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->

![chat-index-page](https://user-images.githubusercontent.com/80025421/149512347-0df3746c-2ca9-44cb-902b-c69c5ef694c9.gif)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- [x] 채팅리스트의 기본 레이아웃 구현
## 💡 포인트 <!-- 구현한 내용 중 추가 설명, 강조가 필요한 핵심 로직이나 코드 설명. '특히 자세히 봐줬으면 좋겠다!'하는 내용들 -->

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
- 헤더부분은 PageHeader를 수정해야할 것 같아 아직 구현하지 않았습니다. 추후 논의후 구현하겠습니다