### PR TITLE
feat#MODI-289 : 알림 기본 UI 구현

### DIFF
--- a/src/components/Common/Header/index.jsx
+++ b/src/components/Common/Header/index.jsx
@@ -11,6 +11,7 @@ import { useCustomThemeDispatch } from 'contexts/CustomThemeProvider.jsx';
 import Brightness7Icon from '@mui/icons-material/Brightness7';
 import Brightness4Icon from '@mui/icons-material/Brightness4';
 import { useTheme } from '@emotion/react';
+import Notice from 'components/Common/Notice.jsx';
 
 const Header = () => {
   const location = useLocation();
@@ -86,6 +87,7 @@ const Header = () => {
               tabSize={mdDownMatches ? 56 : 72}
               mode={theme.palette.mode}
             />
+            <Notice badgeContent={10} />
             <HeaderFab user={isLoggedIn} isMainPage={isMainPage} />
           </Box>
         </Container>

--- a/src/components/Common/Notice.jsx
+++ b/src/components/Common/Notice.jsx
@@ -1,0 +1,18 @@
+import PropTypes from 'prop-types';
+
+import { NotificationsActive } from '@mui/icons-material';
+import { Badge } from '@mui/material';
+
+const Notice = ({ badgeContent }) => {
+  return (
+    <Badge badgeContent={badgeContent} color="error">
+      <NotificationsActive />
+    </Badge>
+  );
+};
+
+Notice.propTypes = {
+  badgeContent: PropTypes.number,
+};
+
+export default Notice;

--- a/src/components/Common/Notification/NoticeItem.jsx
+++ b/src/components/Common/Notification/NoticeItem.jsx
@@ -4,7 +4,8 @@ import { OttLogo } from 'components/Ott';
 import PropTypes from 'prop-types';
 
 const NoticeItem = ({ notice }) => {
-  const { partyId, partyLeader, ottName, time, message } = notice;
+  const { partyId, partyLeaderName, ottName, createdAt, content, readCheck } =
+    notice;
 
   return (
     <ListItem
@@ -32,7 +33,7 @@ const NoticeItem = ({ notice }) => {
         }}
       >
         <Typography variant="smallB" component="span">
-          {partyLeader}의 {ottName}
+          {partyLeaderName}의 {ottName}
         </Typography>
         <Typography
           variant="small"
@@ -42,10 +43,10 @@ const NoticeItem = ({ notice }) => {
             ml: 1,
           }}
         >
-          {time}
+          {createdAt}
         </Typography>
         <Typography variant="base" component="p">
-          {message}
+          {content}
         </Typography>
       </Box>
     </ListItem>

--- a/src/components/Common/Notification/NoticeItem.jsx
+++ b/src/components/Common/Notification/NoticeItem.jsx
@@ -1,0 +1,59 @@
+import { Link } from 'react-router-dom';
+import { Box, ListItem, Typography } from '@mui/material';
+import { OttLogo } from 'components/Ott';
+import PropTypes from 'prop-types';
+
+const NoticeItem = ({ notice }) => {
+  const { partyId, partyLeader, ottName, time, message } = notice;
+
+  return (
+    <ListItem
+      sx={{
+        borderBottom: '1px solid #eee',
+        alignItems: 'flex-start',
+        padding: '12px 0',
+      }}
+    >
+      <OttLogo
+        ottName={ottName}
+        size={24}
+        sx={{
+          mt: '4px',
+          mr: 1,
+        }}
+      />
+      <Box
+        to={`/${partyId}`}
+        component={Link}
+        sx={{
+          display: 'block',
+          color: 'inherit',
+          textDecoration: 'none',
+        }}
+      >
+        <Typography variant="smallB" component="span">
+          {partyLeader}의 {ottName}
+        </Typography>
+        <Typography
+          variant="small"
+          component="span"
+          sx={{
+            color: 'modiGray.main',
+            ml: 1,
+          }}
+        >
+          {time}
+        </Typography>
+        <Typography variant="base" component="p">
+          {message}
+        </Typography>
+      </Box>
+    </ListItem>
+  );
+};
+
+export default NoticeItem;
+
+NoticeItem.propTypes = {
+  notice: PropTypes.object,
+};

--- a/src/components/Common/Notification/NoticeList.jsx
+++ b/src/components/Common/Notification/NoticeList.jsx
@@ -5,62 +5,51 @@ import CloseIcon from '@mui/icons-material/Close';
 import PropTypes from 'prop-types';
 
 const NoticeList = ({ onClickClose }) => {
-  const notices = [
+  const notificationResponses = [
     {
-      noticeId: 1,
+      id: 1,
+      content: '공유계정 정보가 변경 되었습니다.',
+      createdAt: '2022-01-18T16:25:23.065224',
+      readCheck: false,
       partyId: '1',
-      partyLeader: '귀여운 강아지',
+      partyLeaderName: '귀여운 강아지',
       ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
     },
     {
-      noticeId: 2,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
+      id: 2,
+      content: '공유계정 정보가 변경되었습니다.',
+      createdAt: '2022-01-18T16:25:22.493746',
+      readCheck: false,
+      partyId: 9,
+      partyLeaderName: '싫은 뻐꾸기',
       ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
     },
     {
-      noticeId: 3,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
+      id: 3,
+      content: '공유계정 정보가 변경되었습니다.',
+      createdAt: '2022-01-18T16:25:23.065224',
+      readCheck: false,
+      partyId: 9,
+      partyLeaderName: '싫은 뻐꾸기',
       ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
     },
     {
-      noticeId: 4,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
+      id: 4,
+      content: '공유계정 정보가 변경되었습니다.',
+      createdAt: '2022-01-18T16:25:23.603224',
+      readCheck: false,
+      partyId: 9,
+      partyLeaderName: '싫은 뻐꾸기',
       ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
     },
     {
-      noticeId: 5,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
+      id: 5,
+      content: '싫은 뻐꾸기님이 파티원으로 참여했습니다.',
+      createdAt: '2022-01-18T16:29:50.037277',
+      readCheck: false,
+      partyId: 10,
+      partyLeaderName: '질긴 코알라',
       ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
-    },
-    {
-      noticeId: 6,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
-      ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
-    },
-    {
-      noticeId: 7,
-      partyId: '1',
-      partyLeader: '귀여운 강아지',
-      ottName: '넷플릭스',
-      time: '21/01/11',
-      message: '공유계정 정보가 변경 되었습니다.',
     },
   ];
 
@@ -91,8 +80,8 @@ const NoticeList = ({ onClickClose }) => {
       </Box>
       <ScrollWrapper>
         <List>
-          {notices.map(notice => (
-            <NoticeItem key={notice.noticeId} notice={notice} />
+          {notificationResponses.map(notice => (
+            <NoticeItem key={notice.id} notice={notice} />
           ))}
         </List>
       </ScrollWrapper>

--- a/src/components/Common/Notification/NoticeList.jsx
+++ b/src/components/Common/Notification/NoticeList.jsx
@@ -1,0 +1,107 @@
+import { Box, IconButton, List, Typography } from '@mui/material';
+import NoticeItem from './NoticeItem';
+import ScrollWrapper from './../ScrollWrapper';
+import CloseIcon from '@mui/icons-material/Close';
+import PropTypes from 'prop-types';
+
+const NoticeList = ({ onClickClose }) => {
+  const notices = [
+    {
+      noticeId: 1,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 2,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 3,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 4,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 5,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 6,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+    {
+      noticeId: 7,
+      partyId: '1',
+      partyLeader: '귀여운 강아지',
+      ottName: '넷플릭스',
+      time: '21/01/11',
+      message: '공유계정 정보가 변경 되었습니다.',
+    },
+  ];
+
+  return (
+    <Box
+      sx={{
+        padding: '24px',
+        background: '#fff',
+        maxWidth: '375px',
+        maxHeight: '470px',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}
+      >
+        <Typography variant="large" component="h2">
+          알림
+        </Typography>
+        <IconButton component="span" sx={{ p: 0 }} onClick={onClickClose}>
+          <CloseIcon />
+        </IconButton>
+      </Box>
+      <ScrollWrapper>
+        <List>
+          {notices.map(notice => (
+            <NoticeItem key={notice.noticeId} notice={notice} />
+          ))}
+        </List>
+      </ScrollWrapper>
+    </Box>
+  );
+};
+
+export default NoticeList;
+
+NoticeList.propTypes = {
+  onClickClose: PropTypes.func,
+};

--- a/src/components/Common/Notification/index.js
+++ b/src/components/Common/Notification/index.js
@@ -1,0 +1,2 @@
+export { default as NoticeList } from './NoticeList';
+export { default as NoticeItem } from './NoticeItem';


### PR DESCRIPTION
## 👀 이미지 또는 Gif <!-- 구현한 내용의 동작을 담은 이미지, gif 등. 시각화된 내용이 없다면 생략 -->
![image](https://user-images.githubusercontent.com/40739041/149888977-76c4835d-1b14-4ce3-a205-17c5fd09646f.png)

## 📝 요구 사항 및 구현 내용 <!-- 구현한 내용의 세부 사항 목록과 완료 여부 체크 -->
- MUI List, ListItem 컴포넌트를 이용하여 UI를 구현했습니다.
- - MUI Popover 컴포넌트를 활용했습니다.
- 각 Item은 prop으로 알림 객체를 받습니다. 
- 현재 더미데이터와 테스트 페이지에서만 확인할 수 있습니다.

## 🚩 이슈 <!-- 해결하지 못한 내용 또는 부족한 점이 있어 추가 논의가 필요할 것 같은 부분에 대한 상세 설명 -->
모바일에서 fullpage로 style을 변경하는 부분은 조사가 더 필요합니다.